### PR TITLE
Calculate the triangle surface using floats

### DIFF
--- a/xs/src/libslic3r/NonplanarFacet.cpp
+++ b/xs/src/libslic3r/NonplanarFacet.cpp
@@ -63,7 +63,10 @@ NonplanarFacet::scale(float versor[3])
 float
 NonplanarFacet::calculate_surface_area()
 {
-    return Slic3r::Geometry::triangle_surface(Point(this->vertex[0].x, this->vertex[0].y), Point(this->vertex[1].x, this->vertex[1].y), Point(this->vertex[2].x, this->vertex[2].y));;
+    return 0.5 * ((this->vertex[1].x - this->vertex[0].x) * 
+		  (this->vertex[2].y - this->vertex[0].y) - 
+		  (this->vertex[1].y - this->vertex[0].y) *
+    		  (this->vertex[2].x - this->vertex[0].x));
 }
 
 }


### PR DESCRIPTION
I discovered this issue where small surfaces (~1 mm2) get their areas calculated incorrectly (zeroed out).

The problem is that `float Geometry::triangle_surface()` takes `Point`, which is `long`. A better solution might be to add version that takes `Pointf`.
