### PR TITLE
3D support in distance_to to fix broken Douglas-Peucker algorithm

### DIFF
--- a/xs/src/libslic3r/MultiPoint.cpp
+++ b/xs/src/libslic3r/MultiPoint.cpp
@@ -178,13 +178,6 @@ MultiPoint::_douglas_peucker(const Points &points, const double tolerance)
 {
     assert(points.size() >= 2);
     Points results;
-    //TODO fix segfault in this function
-    //Temporary
-    for (Point p : points) {
-        results.push_back(p);
-    }
-    return results;
-    ///Temporary
     
     double dmax = 0;
     size_t index = 0;

--- a/xs/src/libslic3r/Point.cpp
+++ b/xs/src/libslic3r/Point.cpp
@@ -198,19 +198,21 @@ Point::distance_to(const Line &line) const
 {
     const double dx = line.b.x - line.a.x;
     const double dy = line.b.y - line.a.y;
+    const double dz = line.b.z - line.a.z;
 
-    const double l2 = dx*dx + dy*dy;  // avoid a sqrt
+    const double l2 = dx*dx + dy*dy + dz*dz;  // avoid a sqrt
     if (l2 == 0.0) return this->distance_to(line.a);   // line.a == line.b case
 
     // Consider the line extending the segment, parameterized as line.a + t (line.b - line.a).
     // We find projection of this point onto the line.
     // It falls where t = [(this-line.a) . (line.b-line.a)] / |line.b-line.a|^2
-    const double t = ((this->x - line.a.x) * dx + (this->y - line.a.y) * dy) / l2;
+    const double t = ((this->x - line.a.x) * dx + (this->y - line.a.y) * dy  + (this->z - line.a.z) * dz) / l2;
     if (t < 0.0)      return this->distance_to(line.a);  // beyond the 'a' end of the segment
     else if (t > 1.0) return this->distance_to(line.b);  // beyond the 'b' end of the segment
     Point projection(
         line.a.x + t * dx,
-        line.a.y + t * dy
+        line.a.y + t * dy,
+        line.a.z + t * dz
     );
     return this->distance_to(projection);
 }


### PR DESCRIPTION
3D support in distance_to to fix broken Douglas-Peucker algorithm in nonplanar gcode export.

The length of exported gcode segments is usually normalized to avoid a high number of very short movements in regions where the facet density in the original stl file is high. This is achieved by the recursive Douglas-Peucker algorithm. The introduction of a z-component to the Point.cpp class for the nonplanar feature has broken the ```distance_to``` method, even in the 2D case, preventing the DP algo from termination, resulting in a stack overflow (segfault).