### PR TITLE
Made the placeholders use proper namespaces (boost::placeholders::_1)

### DIFF
--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -3,6 +3,7 @@
 #include "ClipperUtils.hpp"
 #include "Geometry.hpp"
 #include <algorithm>
+#include <boost/bind/bind.hpp>
 #include <vector>
 #include "SVG.hpp"
 
@@ -345,7 +346,7 @@ PrintObject::detect_surfaces_type()
 
     parallelize<Layer*>(
         std::queue<Layer*>(std::deque<Layer*>(this->layers.begin(), this->layers.end())),  // cast LayerPtrs to std::queue<Layer*>
-        boost::bind(&Slic3r::Layer::detect_surfaces_type, _1),
+        boost::bind(&Slic3r::Layer::detect_surfaces_type, boost::placeholders::_1),
         this->_print->config.threads.value
     );
 
@@ -612,7 +613,7 @@ PrintObject::project_nonplanar_surfaces()
     this->state.set_started(posNonplanarProjection);
     parallelize<Layer*>(
         std::queue<Layer*>(std::deque<Layer*>(this->layers.begin(), this->layers.end())),  // cast LayerPtrs to std::queue<Layer*>
-        boost::bind(&Slic3r::Layer::project_nonplanar_surfaces, _1),
+        boost::bind(&Slic3r::Layer::project_nonplanar_surfaces, boost::placeholders::_1),
         this->_print->config.threads.value
     );
 
@@ -624,7 +625,7 @@ PrintObject::process_external_surfaces()
 {
     parallelize<Layer*>(
         std::queue<Layer*>(std::deque<Layer*>(this->layers.begin(), this->layers.end())),  // cast LayerPtrs to std::queue<Layer*>
-        boost::bind(&Slic3r::Layer::process_external_surfaces, _1),
+        boost::bind(&Slic3r::Layer::process_external_surfaces, boost::placeholders::_1),
         this->_print->config.threads.value
     );
 }
@@ -1394,7 +1395,7 @@ PrintObject::_make_perimeters()
 
     parallelize<Layer*>(
         std::queue<Layer*>(std::deque<Layer*>(this->layers.begin(), this->layers.end())),  // cast LayerPtrs to std::queue<Layer*>
-        boost::bind(&Slic3r::Layer::make_perimeters, _1),
+        boost::bind(&Slic3r::Layer::make_perimeters, boost::placeholders::_1),
         this->_print->config.threads.value
     );
 
@@ -1416,7 +1417,7 @@ PrintObject::_infill()
 
     parallelize<Layer*>(
         std::queue<Layer*>(std::deque<Layer*>(this->layers.begin(), this->layers.end())),  // cast LayerPtrs to std::queue<Layer*>
-        boost::bind(&Slic3r::Layer::make_fills, _1),
+        boost::bind(&Slic3r::Layer::make_fills, boost::placeholders::_1),
         this->_print->config.threads.value
     );
 

--- a/xs/src/libslic3r/SLAPrint.cpp
+++ b/xs/src/libslic3r/SLAPrint.cpp
@@ -6,6 +6,7 @@
 #include "Surface.hpp"
 #include <iostream>
 #include <complex>
+#include <boost/bind/bind.hpp>
 #include <cstdio>
 
 namespace Slic3r {
@@ -67,7 +68,7 @@ SLAPrint::slice()
         parallelize<size_t>(
             0,
             this->layers.size()-1,
-            boost::bind(&SLAPrint::_infill_layer, this, _1, fill.get()),
+            boost::bind(&SLAPrint::_infill_layer, this, boost::placeholders::_1, fill.get()),
             this->config.threads.value
         );
     }

--- a/xs/src/libslic3r/TriangleMesh.cpp
+++ b/xs/src/libslic3r/TriangleMesh.cpp
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <boost/config.hpp>
 #include <boost/nowide/convert.hpp>
+#include <boost/bind/bind.hpp>
 
 #ifdef SLIC3R_DEBUG
 #include "SVG.hpp"
@@ -771,7 +772,7 @@ TriangleMeshSlicer<A>::slice(const std::vector<float> &z, std::vector<Polygons>*
         parallelize<int>(
             0,
             this->mesh->stl.stats.number_of_facets-1,
-            boost::bind(&TriangleMeshSlicer<A>::_slice_do, this, _1, &lines, &lines_mutex, z)
+            boost::bind(&TriangleMeshSlicer<A>::_slice_do, this, boost::placeholders::_1, &lines, &lines_mutex, z)
         );
     }
 
@@ -782,7 +783,7 @@ TriangleMeshSlicer<A>::slice(const std::vector<float> &z, std::vector<Polygons>*
     parallelize<size_t>(
         0,
         lines.size()-1,
-        boost::bind(&TriangleMeshSlicer<A>::_make_loops_do, this, _1, &lines, layers)
+        boost::bind(&TriangleMeshSlicer<A>::_make_loops_do, this, boost::placeholders::_1, &lines, layers)
     );
 }
 


### PR DESCRIPTION
It did not want to compile for my system (arch linux), but now it works.
The problem was that the compiler didn't understand that `_1` was placeholder in the `bind` functions.
I just changed all instances of it to `boost::placeholders::_1` and it compiled correctly. I only did this to the ones that the compiler was complaining about. I don't know if this is a problem for others, but the pragma message said not using namespaces was obsolete anyway.